### PR TITLE
Allow cors on backend 

### DIFF
--- a/Backend/src/main/java/msc/HME/controller/PropertiesController.java
+++ b/Backend/src/main/java/msc/HME/controller/PropertiesController.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RestController
+@CrossOrigin(origins = "*")
 @RequestMapping("/api/properties")
 public class PropertiesController {
     //logger refactoring?


### PR DESCRIPTION
## What did we do?
To allow the frontend to connect to the backend, the endpoint had to send back cors origins 

## Why did we do it?
without no application no no 
